### PR TITLE
add misdreavus to r+

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -83,6 +83,7 @@ reviewers = [
   "Mark-Simulacrum",
   "aidanhs",  
   "dtolnay",
+  "QuietMisdreavus",
 ]
 
 # who has 'try' rights? (try, retry, force, clean, prioritization)


### PR DESCRIPTION
I'm starting to review PRs for docs and rustdoc, and forcing someone to r= or delegate for me is getting unsustainable. `>_>`