### PR TITLE
Don't expect try results from appveyor.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cargo install \
 
 # Install homu, our integration daemon
 RUN git clone https://github.com/servo/homu /homu
-RUN cd /homu && git reset --hard b82e98b628a2f8483f09b22ea75186b20b78cede
+RUN cd /homu && git reset --hard 39c40e0bccb12652ad7fe6f6637c37105625b072
 RUN pip3 install -e /homu
 
 # Install local programs used:

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -1,3 +1,5 @@
+max_priority = 9001
+
 [db]
 file = '/src/data/main.db'
 
@@ -12,6 +14,7 @@ access_token = "{{ homu.github.access-token }}"
 # A GitHub oauth application for this instance of homu:
 app_client_id = "{{ homu.github.app-client-id }}"
 app_client_secret = "{{ homu.github.app-client-secret }}"
+
 
 [git]
 
@@ -98,6 +101,7 @@ secret = "{{ homu.repo-secrets.rust }}"
 context = "continuous-integration/travis-ci/push"
 [repo.rust.status.appveyor]
 context = "continuous-integration/appveyor/branch"
+try = false
 
 
 [repo.cargo]


### PR DESCRIPTION
This pulls servo/homu#124 to get support for homu having a limited set of statuses it expects for try builds, and sets that for appveyor for rust-lang/rust.