### PR TITLE
Don't mount src as a volume, keep data separate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,11 @@ RUN cd /s3-directory-listing && git reset --hard 1dc88c6b0f6c4df470d35d1c212ee65
 ADD crontab /etc/cron.d/rcs
 RUN chmod 0644 /etc/cron.d/rcs
 
-# And finally, initialize our known set of ssh hosts so git doesn't prompt us
-# later.
+# Initialize our known set of ssh hosts so git doesn't prompt us later.
 RUN mkdir /root/.ssh && ssh-keyscan github.com >> /root/.ssh/known_hosts
+
+# Copy the source directory into the image so we can run scripts and template
+# configs from there
+COPY . /src/
 
 CMD ["/src/bin/run.sh"]

--- a/bin/cancelbot-cargo.sh
+++ b/bin/cancelbot-cargo.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-secrets=/src/data/secrets.toml
+secrets=/data/secrets.toml
 
 exec cancelbot \
   --travis `tq cancelbot.travis-token < $secrets` \

--- a/bin/cancelbot-rust.sh
+++ b/bin/cancelbot-rust.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-secrets=/src/data/secrets.toml
+secrets=/data/secrets.toml
 
 exec cancelbot \
   --travis `tq cancelbot.travis-token < $secrets` \

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-secrets=/src/data/secrets.toml
+secrets=/data/secrets.toml
 
 # We mounted /var/log from a local log dir, but ubuntu expects it to be owned by
 # root:syslog, so change it here

--- a/crontab
+++ b/crontab
@@ -4,9 +4,9 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.cargo/b
 24 * * * * root letsencrypt renew 2>&1 | logger --tag letsencrypt-renew
 
 # signing/hashing/promoting releases
-0 0 * * * root promote-release /tmp/nightly nightly /src/data/secrets.toml 2>&1 | logger --tag release-nightly
-20 * * * * root promote-release /tmp/beta beta /src/data/secrets.toml 2>&1 | logger --tag release-beta
-40 * * * * root promote-release /tmp/stable stable /src/data/secrets-dev.toml 2>&1 | logger --tag release-stable
+0 0 * * * root promote-release /tmp/nightly nightly /data/secrets.toml 2>&1 | logger --tag release-nightly
+20 * * * * root promote-release /tmp/beta beta /data/secrets.toml 2>&1 | logger --tag release-beta
+40 * * * * root promote-release /tmp/stable stable /data/secrets-dev.toml 2>&1 | logger --tag release-stable
 
 # cancelling appveyor/travis builds if we don't need them
 */2 * * * * root /src/bin/cancelbot-rust.sh 2>&1 | logger --tag cancelbot-rust

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -1,7 +1,7 @@
 max_priority = 9001
 
 [db]
-file = '/src/data/main.db'
+file = '/data/main.db'
 
 [github]
 

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -8,8 +8,7 @@ docker build \
   .
 
 exec docker run \
-  --volume `pwd`:/src:ro \
-  --volume `pwd`/data:/src/data \
+  --volume `pwd`/data:/data \
   --volume `pwd`/data/letsencrypt:/etc/letsencrypt \
   --env DEV=1 \
   --publish 8080:80 \

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -6,8 +6,7 @@ docker pull alexcrichton/rust-central-station
 
 mkdir -p data/logs/nginx
 exec docker run \
-  --volume `pwd`:/src:ro \
-  --volume `pwd`/data:/src/data \
+  --volume `pwd`/data:/data \
   --volume `pwd`/data/letsencrypt:/etc/letsencrypt \
   --volume `pwd`/data/logs:/var/log \
   --publish 80:80 \

--- a/secrets.toml.example
+++ b/secrets.toml.example
@@ -44,8 +44,8 @@ token = "sekret" # GH token
 [dist]
 
 # File with the actual key as well as the path to a file with the password
-gpg-key = "/src/data/gpg.key"
-gpg-password-file = "/src/data/gpg.password"
+gpg-key = "/data/gpg.key"
+gpg-password-file = "/data/gpg.password"
 
 # Remote HTTP host artifacts will be uploaded to. Note that this is *not* the
 # same as what's configured in `config.toml` for rustbuild, it's just the *host*


### PR DESCRIPTION
On merging this PR you'll need to
 - update the actual secrets.toml to refer to `/data` rather than `/src/data`
 - remove the cloned RCS repo on the production server (leave data and logs alone though!) - it's inside the image now

The intention is to have less content on the RCS server. Secrets are hard so I'm not touching them for now, but there's no reason to have the git repo on there.