### PR TITLE
Update rplus lists

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -38,52 +38,87 @@ name = "rust"
 
 # who has r+ rights?
 reviewers = [
-  "Aatch",
+  # core
+  "nrc",
+  "alexcrichton",
+  "steveklabnik",
+  "nikomatsakis",
+  "carols10cents",
+  "aturon",
+  "erickt",
+
+  # lang
+  "eddyb",
+  # also on core: "nrc",
+  "pnkfelix",
+  # also on core: "nikomatsakis",
+  # also on core: "aturon",
+
+  # libs
+  # also on core: "alexcrichton",
+  "sfackler",
   "BurntSushi",
-  "FlaPer87",
+  "Kimundi",
+  "dtolnay",
+  # also on core: "aturon",
+
+  # compiler
+  "arielb1",
+  # also on lang: "eddyb",
+  "estebank",
+  # also on core: "nrc",
+  "petrochenkov",
+  # also on lang: "pnkfelix",
+  # also on core: "nikomatsakis",
+  "jseyfried",
+  "michaelwoerister",
+
+  # dev tools
+  "japaric",
+  "jonathandturner",
+  # also on compiler: "michaelwoerister",
+  # also on core: "nrc",
+
+  # infra
+  # also on core: "alexcrichton",
+  "shepmaster",
+  "aidanhs",
+  "TimNN",
+  # also on core: "carols10cents",
+  "Mark-Simulacrum",
+  # also on core: "erickt",
+  # also on core: "aturon",
+
+  # docs
+  # also on core: "steveklabnik",
   "GuillaumeGomez",
+  "frewsxcv",
+  "QuietMisdreavus",
+
+  # alumni
+  "Aatch",
+  "pcwalton",
+  "huonw",
+  "dotdash",
+  "bkoropoff",
+
+  # bots
+  "bors",
+
+  # other
+  "FlaPer87",
   "Luqmana",
   "Manishearth",
-  "alexcrichton",
   "apasel422",
-  "arielb1",
-  "bkoropoff",
   "bluss",
-  "bors",
   "bstrie",
   "cmr",
-  "dotdash",
-  "eddyb",
-  "erickt",
-  "estebank",
-  "frewsxcv",
-  "huonw",
-  "japaric",
   "jdm",
-  "jonathandturner",
   "jroesch",
-  "jseyfried",
   "kballard",
-  "michaelwoerister",
-  "nikomatsakis",
-  "nrc",
-  "pcwalton",
-  "petrochenkov",
-  "pnkfelix",
   "sanxiyn",
-  "sfackler",
-  "steveklabnik",
   "vadimcn",
-  "aturon",
-  "TimNN",
-  "carols10cents",
   "nagisa",
-  "Kimundi",
-  "shepmaster",
-  "Mark-Simulacrum",
-  "aidanhs",
-  "dtolnay",
-  "QuietMisdreavus",
 ]
 
 # who has 'try' rights? (try, retry, force, clean, prioritization)

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -64,7 +64,6 @@ reviewers = [
   "jroesch",
   "jseyfried",
   "kballard",
-  "kimundi",
   "michaelwoerister",
   "nikomatsakis",
   "nrc",

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -65,7 +65,6 @@ reviewers = [
   "jseyfried",
   "kballard",
   "kimundi",
-  "kmcallister",
   "michaelwoerister",
   "nikomatsakis",
   "nrc",

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -147,12 +147,21 @@ try = false
 owner = "rust-lang"
 name = "cargo"
 reviewers = [
+  # cargo team
   "alexcrichton",
+  "carols10cents",
+  "withoutboats",
+  "matklad",
   "wycats",
+  "joshtriplett",
+  "aturon",
+
+  # alumni
   "carllerche",
   "huonw",
+
+  # other
   "steveklabnik",
-  "matklad",
   "Mark-Simulacrum",
 ]
 try_users = []

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -41,6 +41,7 @@ reviewers = [
   # core
   "nrc",
   "alexcrichton",
+  "wycats",
   "steveklabnik",
   "nikomatsakis",
   "carols10cents",
@@ -48,6 +49,8 @@ reviewers = [
   "erickt",
 
   # lang
+  "cramertj",
+  "withoutboats",
   "eddyb",
   # also on core: "nrc",
   "pnkfelix",
@@ -74,8 +77,11 @@ reviewers = [
   "michaelwoerister",
 
   # dev tools
+  "fitzgen",
   "japaric",
   "jonathandturner",
+  "killercup",
+  "matklad",
   # also on compiler: "michaelwoerister",
   # also on core: "nrc",
 
@@ -87,6 +93,8 @@ reviewers = [
   # also on core: "carols10cents",
   "Mark-Simulacrum",
   # also on core: "erickt",
+  "tomprince",
+  "kennytm",
   # also on core: "aturon",
 
   # docs
@@ -124,8 +132,6 @@ reviewers = [
 # who has 'try' rights? (try, retry, force, clean, prioritization)
 try_users = [
   "est31",
-  "tomprince",
-  "kennytm",
 ]
 
 [repo.rust.github]


### PR DESCRIPTION
I was looking at the list of r+ers by team that we have in the PR tracking spreadsheet and noticed it was out of date, and then I started looking at this list and noticed it was out of date with the teams page.

I did some reorganization to hopefully make auditing this against the teams page easier in the future. I tried to keep the reorg commit separate from the commits adding/removing people; hopefully this won't be toooo terrible to review.