### PR TITLE
Give @JoshTriplett, @KodrAus and @rkruppe r+ rights on rust-lang/rust

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -56,6 +56,7 @@ reviewers = [
   "pnkfelix",
   # also on core: "nikomatsakis",
   # also on core: "aturon",
+  "JoshTriplett",
 
   # libs
   # also on core: "alexcrichton",
@@ -128,6 +129,8 @@ reviewers = [
   "sanxiyn",
   "vadimcn",
   "nagisa",
+  "KodrAus",
+  "rkruppe",
 ]
 
 # who has 'try' rights? (try, retry, force, clean, prioritization)


### PR DESCRIPTION
Rationale: These people [can be assigned](https://github.com/nrc/highfive/blob/master/highfive/configs/rust.json) by @rust-highfive, but they did not have r+ rights, causing hilarious errors like rust-lang/rust#46141. (Either merge this or remove their names from highfive.)