### PR TITLE
Align dates in rustup toolchains with those in `rustc -V`

### DIFF
--- a/promote-release/src/main.rs
+++ b/promote-release/src/main.rs
@@ -44,7 +44,8 @@ fn main() {
         release: env::args().nth(2).unwrap(),
         secrets: t!(secrets.parse()),
         handle: Easy::new(),
-        date: output(Command::new("date").arg("+%Y-%m-%d")).trim().to_string(),
+        date: output(Command::new("date").arg("--date=10 minutes ago").arg("+%Y-%m-%d"))
+	    .trim().to_string(),
         current_version: None,
     }.run()
 }

--- a/promote-release/src/main.rs
+++ b/promote-release/src/main.rs
@@ -44,6 +44,10 @@ fn main() {
         release: env::args().nth(2).unwrap(),
         secrets: t!(secrets.parse()),
         handle: Easy::new(),
+	// For Nightly, this is running soon after midnight
+	// so the date of 10 minutes ago is yesterday,
+	// which likely matches the commit date of the latest commit on the master branch:
+	// https://github.com/rust-lang/rust-central-station/pull/27
         date: output(Command::new("date").arg("--date=10 minutes ago").arg("+%Y-%m-%d"))
 	    .trim().to_string(),
         current_version: None,


### PR DESCRIPTION
`rustup update` tells me that the current Nightly is `rustc 1.24.0-nightly (cfba0d446 2017-12-05)`. This is the output of `rustc --version`. It’s tempting to think that I can pin to this version by specifying a `nightly-2017-12-05` toolchain, but that actually refers to yesterday’s Nightly, `rust version 1.24.0-nightly (8503b3ff8 2017-12-04)`. This discrepancy also makes statements like “I can reproduce bug X in Nightly 2017-12-05” ambiguous.

The reason is that `rustc -V` contains the commit date of whatever happened to be the latest commit in master when a Nightly was published, but the archive URL (and so the toolchain names) contains the date that is current at that time. Since publication is started at midnight UTC, the latest commit is almost always "yesterday" and the dates end up off by one.

(This is technically a race condition but one that commits can never win since testing a PR takes a couple hours. Bors makes a merge commit before testing, and (if successful) pushes to master afterwards. So the latest commit in master is always at least a couple hours old.)

This PR changes the archive URL / toolchain name date to that of "10 minutes ago" instead of "now", soon after Cron starts this program at midnight UTC. That way, the date will most often match that the latest commit. (It can still be off if nothing was merged the day before, but given PR traffic on rust-lang/rust that’s relatively rare.)

This change should probably not be deployed without precaution since at the transition we’d end up with two nightlies with the same date and same URLs. The second one would probably overwrite the first, which is unexpected for dated archive URLs that have been so far immutable. Instead, we may want to skip one nightly (maybe by temporarily disabling the crontab) so that for example `nightly-2017-12-07` is published at the end of that day (soon after midnight) and `nightly-2017-12-08` after the end of that day, about 48 hours later.