### PR TITLE
Customize bors timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cargo install \
 
 # Install homu, our integration daemon
 RUN git clone https://github.com/servo/homu /homu
-RUN cd /homu && git reset --hard 39c40e0bccb12652ad7fe6f6637c37105625b072
+RUN cd /homu && git reset --hard 11ef9469e5a6c71b66cd602e515d6a8689d0783e
 RUN pip3 install -e /homu
 
 # Install local programs used:

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -35,6 +35,7 @@ port = 7942
 [repo.rust]
 owner = "rust-lang"
 name = "rust"
+timeout = 14400
 
 # who has r+ rights?
 reviewers = [
@@ -151,6 +152,8 @@ try = false
 [repo.cargo]
 owner = "rust-lang"
 name = "cargo"
+timeout = 7200
+
 reviewers = [
   # cargo team
   "alexcrichton",
@@ -182,6 +185,8 @@ context = "continuous-integration/appveyor/branch"
 [repo.libc]
 owner = "rust-lang"
 name = "libc"
+timeout = 9000
+
 reviewers = [
   "alexcrichton",
   "malbarbo",
@@ -202,6 +207,8 @@ context = "continuous-integration/appveyor/branch"
 [repo.rustup-rs]
 owner = "rust-lang-nursery"
 name = "rustup.rs"
+timeout = 12600
+
 reviewers = [
   "alexcrichton",
   "Diggsey",
@@ -245,6 +252,8 @@ context = "continuous-integration/appveyor/branch"
 [repo.regex]
 owner = "rust-lang"
 name = "regex"
+timeout = 5400
+
 reviewers = [
   "BurntSushi",
 ]


### PR DESCRIPTION
(This requires updating homu to include servo/homu#142.)

The timeout is reduced from homu's default 10 hours, so that even if bors failed to pick up CI's notification it won't block the queue the whole half-day.

The timeouts are arbitrarily chosen according to the median wall-clock duration of the last 5 successful PRs.

| Repository | Timeout (this PR) | Last 5 successful tests |
|------------|---------|------------------------|
| rust-lang/rust | 4.0 hr | 2.9 hr / 3.7 hr / 2.8 hr / 2.9 hr / 2.9 hr |
| rust-lang/cargo | 2.0 hr | 0.5 hr / 0.6 hr / 0.5 hr / 0.9 hr / 0.7 hr |
| rust-lang/libc | 2.5 hr | 1.1 hr / 1.0 hr / 0.4 hr / 0.6 hr / 3.0 hr |
| rust-lang-nursery/rustup.rs | 3.5 hr | 4.5 hr / 1.1 hr / 2.2 hr / 2.0 hr / 1.7 hr |
| rust-lang/regex | 1.5 hr | 0.3 hr / 0.2 hr / 0.6 hr / 1.0 hr / 0.5 hr |
