### PR TITLE
Let bors automatically manage the S- labels.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cargo install \
 
 # Install homu, our integration daemon
 RUN git clone https://github.com/servo/homu /homu
-RUN cd /homu && git reset --hard 11ef9469e5a6c71b66cd602e515d6a8689d0783e
+RUN cd /homu && git reset --hard 0979fe7151a43fabd4925187ab1f97100bf4d400
 RUN pip3 install -e /homu
 
 # Install local programs used:

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -148,6 +148,37 @@ context = "continuous-integration/travis-ci/push"
 context = "continuous-integration/appveyor/branch"
 try = false
 
+# Automatic relabeling
+[repo.rust.labels.approved]   # after homu received `r+`
+remove = ['S-blocked', 'S-waiting-on-author', 'S-waiting-on-bors', 'S-waiting-on-crater', 'S-waiting-on-review', 'S-waiting-on-team']
+add = ['S-waiting-on-bors']
+
+[repo.rust.labels.rejected]   # after homu received `r-`
+remove = ['S-blocked', 'S-waiting-on-author', 'S-waiting-on-bors', 'S-waiting-on-crater', 'S-waiting-on-review', 'S-waiting-on-team']
+add = ['S-waiting-on-author']
+
+[repo.rust.labels.failed]     # test failed (maybe spurious, so fall back to -on-review)
+remove = ['S-blocked', 'S-waiting-on-author', 'S-waiting-on-bors', 'S-waiting-on-crater', 'S-waiting-on-review', 'S-waiting-on-team']
+add = ['S-waiting-on-review']
+
+[repo.rust.labels.timed_out]   # test timed out after 4 hours (almost always spurious, let reviewer retry)
+remove = ['S-blocked', 'S-waiting-on-author', 'S-waiting-on-bors', 'S-waiting-on-crater', 'S-waiting-on-review', 'S-waiting-on-team']
+add = ['S-waiting-on-review']
+
+[repo.rust.labels.try_failed]  # try-build failed (almost always legit, tell author to fix the PR)
+remove = ['S-waiting-on-review', 'S-waiting-on-crater']
+add = ['S-waiting-on-author']
+
+[repo.rust.labels.pushed]      # user pushed a commit after `r+`/`try`
+remove = ['S-waiting-on-bors', 'S-waiting-on-author']
+add = ['S-waiting-on-review']
+unless = ['S-blocked', 'S-waiting-on-crater', 'S-waiting-on-team']
+
+[repo.rust.labels.conflict]    # a merge conflict is detected (tell author to rebase)
+remove = ['S-waiting-on-bors', 'S-waiting-on-review']
+add = ['S-waiting-on-author']
+unless = ['S-blocked', 'S-waiting-on-crater', 'S-waiting-on-team']
+
 
 [repo.cargo]
 owner = "rust-lang"


### PR DESCRIPTION
Close #16. (See servo/homu#141 for implementation.)

This PR makes bors recognize the following events:

| Scenario | New label | Reason |
|---|---|---|
| `r+` | S-waiting-on-bors | |
| `r-` | S-waiting-on-author | |
| test failure or timeout | S-waiting-on-review | because it is possible the failure is spurious, we nag the reviewer to investigate the reason first |
| try failure | S-waiting-on-author | try failure is almost always legit i.e. the author needs to change the code anyway |
| pushed a commit after `r+` | S-waiting-on-review | the PR is removed from the queue and the reviewer should check the new commit |
| merge conflict | S-waiting-on-author | author needs to rebase |

The actual rules are a bit more complex since there are 3 other S- labels to consider. Please check the diff for details.

The effect is that PR triage should never need to manage the S-waiting-on-bors state anymore.  