### PR TITLE
Do not change `S-waiting-on-review` to `S-waiting-on-author` on merge conflict

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -176,9 +176,9 @@ add = ['S-waiting-on-review']
 unless = ['S-blocked', 'S-waiting-on-crater', 'S-waiting-on-team']
 
 [repo.rust.labels.conflict]    # a merge conflict is detected (tell author to rebase)
-remove = ['S-waiting-on-bors', 'S-waiting-on-review']
+remove = ['S-waiting-on-bors']
 add = ['S-waiting-on-author']
-unless = ['S-blocked', 'S-waiting-on-crater', 'S-waiting-on-team']
+unless = ['S-blocked', 'S-waiting-on-crater', 'S-waiting-on-team', 'S-waiting-on-review']
 
 
 [repo.cargo]


### PR DESCRIPTION
If a PR was waiting for review before the merge conflict, it's still waiting for review after.

In most cases merge conflicts do not prevent reviewing and it's not necessary for PR authors to rebase all the time to get reviewer's attention, one rebase in the end before r+ is usually enough.