### PR TITLE
Add @eh2406 to Cargo reviewers

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -221,6 +221,7 @@ reviewers = [
   # other
   "steveklabnik",
   "Mark-Simulacrum",
+  "Eh2406",
 ]
 try_users = []
 [repo.cargo.branch]


### PR DESCRIPTION
cc @rust-lang/cargo 

@eh2406 is doing a ton of implementation work in the most complex resolver part, and helps with issue and PR triage a lot. Looks like we should add them to reviewers? 

r? @alexcrichton 