### PR TITLE
Add @ehuss to cargo reviewers

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -219,6 +219,7 @@ reviewers = [
   "huonw",
 
   # other
+  "ehuss",
   "steveklabnik",
   "Mark-Simulacrum",
 ]


### PR DESCRIPTION
cc @rust-lang/cargo 

@alexcrichton and @matklad are consistently blown away by the quality *and* quantity of the work done by @ehuss, be it [a new major feature](https://github.com/rust-lang/cargo/pull/5384), an [especially elusive heisenbug](https://github.com/rust-lang/cargo/pull/5493), or *just* [keeping an eye on Cargo to make sure something insane doesn't happen](https://github.com/rust-lang/cargo/issues/5526#issue-322533761). Seems like we should add them to reviewers? :) 

r? @alexcrichton 