### PR TITLE
Homu: check the Cirrus status for libc builds.

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -263,6 +263,8 @@ secret = "{{ homu.repo-secrets.libc }}"
 context = "continuous-integration/travis-ci/push"
 [repo.libc.status.appveyor]
 context = "continuous-integration/appveyor/branch"
+[repo.libc.status.cirrus]
+context = "stable x86_64-unknown-freebsd"
 
 [repo.rustup-rs]
 owner = "rust-lang-nursery"


### PR DESCRIPTION
Suggested by @alexcrichton in https://github.com/rust-lang/libc/pull/1167