### PR TITLE
Revert "Homu: check the Cirrus status for libc builds."

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -263,8 +263,6 @@ secret = "{{ homu.repo-secrets.libc }}"
 context = "continuous-integration/travis-ci/push"
 [repo.libc.status.appveyor]
 context = "continuous-integration/appveyor/branch"
-[repo.libc.status.cirrus]
-context = "stable x86_64-unknown-freebsd"
 
 [repo.rustup-rs]
 owner = "rust-lang-nursery"


### PR DESCRIPTION
Reverts rust-lang/rust-central-station#120

Homu doesn't know how to read GitHub check-suites, and Cirrus uses them exclusively.  Revert this commit until we can fix the problem, probably by switching from Homu to Bors.