### PR TITLE
Configure bors for crates.io

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -376,3 +376,22 @@ secret = "{{ homu.repo-secrets.clippy }}"
 context = "continuous-integration/travis-ci/push"
 [repo.clippy.status.appveyor]
 context = "continuous-integration/appveyor/branch"
+
+[repo.crates-io]
+owner = "rust-lang"
+name = "crates.io"
+timeout = 5400
+
+reviewers = [
+  "carols10cents",
+  "sgrif",
+  "jtgeibel",
+]
+try_users = []
+
+[repo.crates-io.github]
+secret = "{{ homu.repo-secrets.crates-io }}"
+[repo.crates-io.checks.travis]
+name = "Travis CI - Branch"
+[repo.crater.status.appveyor]
+context = "continuous-integration/appveyor/branch"


### PR DESCRIPTION
**Do not merge this yet**, let's configure bors when we migrate the repo to travis-ci.com.

In their meeting the crates.io team agreed to move from bors-ng to homu, and this PR adds the configuration to make it happen. List of reviewers allowed to merge code:

* @carols10cents 
* @sgrif
* @jtgeibel

After this PR is merged someone will need to add a new secret key on the RCS machine and configure the webhook with it.

cc @rust-lang/crates-io 