### PR TITLE
Deploy to ECR from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 language: minimal
-script: docker build .
+script: docker build -t rust-central-station .
+deploy:
+  provider: script
+  script: sh deploy.sh
+  on:
+    branch: master

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+$(aws ecr get-login --no-include-email --region us-west-1)
+docker tag rust-central-station:latest 890664054962.dkr.ecr.us-west-1.amazonaws.com/rust-central-station:latest
+docker push 890664054962.dkr.ecr.us-west-1.amazonaws.com/rust-central-station:latest


### PR DESCRIPTION
Let's avoid using Docker Hub as we don't really use it for anything
else! Also allows builds to happen on Travis rather than externally