### PR TITLE
Try to initially set up bors for RLS

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -380,6 +380,22 @@ name = "Travis CI - Branch"
 [repo.clippy.status.appveyor]
 context = "continuous-integration/appveyor/branch"
 
+[repo.rls]
+owner = "rust-lang"
+name = "rls"
+timeout = 5400
+
+reviewers = [
+  "nrc",
+  "Xanewok",
+]
+try_users = []
+
+[repo.rls.github]
+secret = "{{ homu.repo-secrets.rls }}"
+[repo.rls.checks.travis]
+name = "Travis CI - Branch"
+
 [repo.crates-io]
 owner = "rust-lang"
 name = "crates.io"

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -388,6 +388,7 @@ timeout = 5400
 reviewers = [
   "nrc",
   "Xanewok",
+  "alexheretic",
 ]
 try_users = []
 


### PR DESCRIPTION
We lost integration with bors-ng since we moved off the https://github.com/rust-lang-nursery orga.

cc @nrc 

r? @pietroalbini 