### PR TITLE
Remove appveyor from crates-io config

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -413,5 +413,3 @@ try_users = []
 secret = "{{ homu.repo-secrets.crates-io }}"
 [repo.crates-io.checks.travis]
 name = "Travis CI - Branch"
-[repo.crates-io.status.appveyor]
-context = "continuous-integration/appveyor/branch"


### PR DESCRIPTION
We've never expected to run it for crates.io.

I'm holding off on merging this to hear back from  @rust-lang/crates-io on whether we want to block landing on "percy" (the visual testing service crates.io uses). If so then we can add that here pretty easily I think.

r? @pietroalbini 


