### PR TITLE
Add the merged-by-bors label to PRs merged by bors

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -215,6 +215,9 @@ remove = ['S-waiting-on-bors']
 add = ['S-waiting-on-author']
 unless = ['S-blocked', 'S-waiting-on-crater', 'S-waiting-on-team', 'S-waiting-on-review']
 
+[repo.rust.labels.succeed]
+add = ['merged-by-bors']
+
 
 [repo.cargo]
 owner = "rust-lang"


### PR DESCRIPTION
This label is going to be used by PR tracking to count PRs explicitly
merged and rollups separately.