### PR TITLE
Synchronize mailing lists with the team repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "run-on-change"
+version = "0.1.0"
+dependencies = [
+ "curl 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +483,11 @@ dependencies = [
  "ryu 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "socket2"
@@ -684,6 +697,7 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
 "checksum serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "27dce848e7467aa0e2fcaf0a413641499c0b745452aaca1194d24dedde9e13c9"
+"checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum socket2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "962a516af4d3a7c272cb3a1d50a8cc4e5b41802e4ad54cfb7bee8ba61d37d703"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,9 +12,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -64,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curl-sys 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -78,7 +109,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,12 +118,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -102,7 +164,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -112,7 +174,7 @@ name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -141,9 +203,25 @@ dependencies = [
  "pest_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "humantime"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -170,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.43"
+version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -179,7 +257,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -199,7 +277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -208,7 +286,7 @@ name = "memchr"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -217,7 +295,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -235,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -250,7 +328,7 @@ version = "0.9.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -274,6 +352,14 @@ dependencies = [
 name = "pkg-config"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "promote-release"
@@ -300,12 +386,20 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quote"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -353,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -399,6 +493,14 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +527,20 @@ dependencies = [
  "curl 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rust_team_data"
+version = "1.0.0"
+source = "git+https://github.com/rust-lang/team#ddeef60918219993a57f7660954d699125c569d0"
+dependencies = [
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc_version"
@@ -471,8 +587,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.71"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_json"
@@ -481,7 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -495,7 +624,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -511,6 +640,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "0.15.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sync-mailgun"
+version = "0.1.0"
+dependencies = [
+ "curl 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synom"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,14 +672,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -542,7 +724,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -560,6 +742,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -625,11 +812,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "xattr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -643,7 +839,10 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
+"checksum backtrace 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eff3830839471718ef8522b9025b399bfb713e25bc220da721364efb660d7d"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
@@ -653,16 +852,21 @@ dependencies = [
 "checksum crc32fast 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e0e685559fa8bccfa46afd0f876047ee5d87c536d71d0c2b3a08cc9e880f73eb"
 "checksum curl 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c8172e96ecfb1a2bfe3843d9d7154099a15130cf4a2f658259c7aa9cc2b5d4ff"
 "checksum curl-sys 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "caae4b699b88e98cb0fc8a8d55efde1ee4142f816219d66fa2b7a450b202db16"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da4b9849e77b13195302c174324b5ba73eec9b236b24c221a61000daefb95c5f"
 "checksum flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4"
 "checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum handlebars 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3623110a77811256820e92df1b3b286f6f44f99d1f77a94b75e262c28d5034f4"
+"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum libz-sys 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "f5f9aba969b3c45fe9c94bec65895868a9ceca9a600699f4054b75747a19c7c6"
 "checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
 "checksum lzma-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d1eaa027402541975218bb0eec67d6b0412f6233af96e0d096d31dbdfd22e614"
@@ -675,8 +879,10 @@ dependencies = [
 "checksum pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc"
 "checksum pest_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3294f437119209b084c797604295f40227cffa35c57220b1e99a6ff3bf8ee4"
 "checksum pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "104630aa1c83213cbc76db0703630fcb0421dac3585063be4ce9a8a2feeaa745"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3906503e80ac6cbcacb2c2973fa8e473f24d7e2747c8c92bb230c2441cad96b5"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
@@ -687,25 +893,34 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "67d0301b0c6804eca7e3c275119d0b01ff3b7ab9258a65709e608a66312a1025"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)" = "<none>"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0568787116e13c652377b6846f5931454a363a8fdf8ae50463ee40935b278b"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
+"checksum serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)" = "9f301d728f2b94c9a7691c90f07b0b4e8a4517181d9461be94c04bddeb4bd850"
+"checksum serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)" = "beed18e6f5175aef3ba670e57c60ef3b1b74d250d962a26604bff4c80e970dd4"
 "checksum serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "27dce848e7467aa0e2fcaf0a413641499c0b745452aaca1194d24dedde9e13c9"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum socket2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "962a516af4d3a7c272cb3a1d50a8cc4e5b41802e4ad54cfb7bee8ba61d37d703"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tar 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "e8f41ca4a5689f06998f0247fcb60da6c760f1950cc9df2a10d71575ad0b062a"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 "checksum vcpkg 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a51475940ea5ed2f7ba8e7b867c42d6cb7f06fafb9c1673ed8e768c675c771cc"
 "checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
@@ -716,5 +931,6 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum xz2 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "df8bf41d3030c3577c9458fd6640a05afbf43b150d0b531b16bd77d3f794f27a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
   "rbars",
   "promote-release",
   "run-on-change",
+  "sync-mailgun",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
   "tq",
   "rbars",
   "promote-release",
+  "run-on-change",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN pip3 install -e /homu
 #                     archives and publish them (also generate manifests)
 # * run-on-change - a command line program to run a command only when the
 #                   content of a web page changes
+# * sync-mailgun - a command line program to synchronize Mailgun mailing lists
+#                  with the team repo
 COPY tq /tmp/tq
 RUN cargo install --path /tmp/tq && rm -rf /tmp/tq
 COPY rbars /tmp/rbars
@@ -66,6 +68,8 @@ COPY promote-release /tmp/promote-release
 RUN cargo install --path /tmp/promote-release && rm -rf /tmp/promote-release
 COPY run-on-change /tmp/run-on-change
 RUN cargo install --path /tmp/run-on-change && rm -rf /tmp/run-on-change
+COPY sync-mailgun /tmp/sync-mailgun
+RUN cargo install --path /tmp/sync-mailgun && rm -rf /tmp/sync-mailgun
 
 # Install commands used by promote-release binary. The awscli package is used to
 # issue cloudfront invalidations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,16 @@ RUN pip3 install -e /homu
 #           in secrets.toml
 # * promote-release - cron job to download artifacts from travis/appveyor
 #                     archives and publish them (also generate manifests)
+# * run-on-change - a command line program to run a command only when the
+#                   content of a web page changes
 COPY tq /tmp/tq
 RUN cargo install --path /tmp/tq && rm -rf /tmp/tq
 COPY rbars /tmp/rbars
 RUN cargo install --path /tmp/rbars && rm -rf /tmp/rbars
 COPY promote-release /tmp/promote-release
 RUN cargo install --path /tmp/promote-release && rm -rf /tmp/promote-release
+COPY run-on-change /tmp/run-on-change
+RUN cargo install --path /tmp/run-on-change && rm -rf /tmp/run-on-change
 
 # Install commands used by promote-release binary. The awscli package is used to
 # issue cloudfront invalidations.

--- a/bin/sync-mailgun.sh
+++ b/bin/sync-mailgun.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+export MAILGUN_API_TOKEN="$(tq mailgun.token < /data/secrets.toml)"
+exec run-on-change https://team-api.infra.rust-lang.org/v1/lists.json sync-mailgun

--- a/crontab
+++ b/crontab
@@ -10,3 +10,6 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.cargo/b
 
 # cancelling appveyor/travis builds if we don't need them
 */2 * * * * root /src/bin/cancelbot-rust.sh 2>&1 | logger --tag cancelbot-rust
+
+# synchronizing mailgun every 5 minutes
+*/5 * * * * root /src/bin/sync-mailgun.sh 2>&1 | logger --tag sync-mailgun

--- a/run-on-change/Cargo.toml
+++ b/run-on-change/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "run-on-change"
+version = "0.1.0"
+authors = ["Pietro Albini <pietro@pietroalbini.org>"]
+edition = "2018"
+
+[dependencies]
+sha1 = "0.6"
+curl = "0.4"

--- a/run-on-change/src/main.rs
+++ b/run-on-change/src/main.rs
@@ -1,0 +1,70 @@
+use sha1::Sha1;
+use std::path::{Path, PathBuf};
+use std::error::Error;
+
+static CACHE_PATH: &str = "/tmp/run-on-change";
+
+fn cached_path(url: &str) -> PathBuf {
+    Path::new(CACHE_PATH).join(Sha1::from(url).digest().to_string())
+}
+
+fn cached_hash(url: &str) -> Result<Option<String>, Box<Error>> {
+    let path = cached_path(url);
+    if path.exists() {
+        Ok(Some(std::fs::read_to_string(&path)?.trim().into()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn fetch_url_hash(url: &str) -> Result<String, Box<Error>> {
+    let mut hash = Sha1::new();
+    let mut easy = curl::easy::Easy::new();
+    easy.url(url)?;
+    easy.useragent("rust-lang infra tooling (https://github.com/rust-lang/rust-central-station)")?;
+    {
+        let mut transfer = easy.transfer();
+        transfer.write_function(|data| {
+            hash.update(data);
+            Ok(data.len())
+        })?;
+        transfer.perform()?;
+    }
+    if easy.response_code()? != 200 {
+        Err(format!("request to {} returned status code {}", url, easy.response_code()?).into())
+    } else {
+        Ok(hash.digest().to_string())
+    }
+}
+
+fn main() -> Result<(), Box<Error>> {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() < 3 {
+        eprintln!("usage: {} <url> <command ...>", args[0]);
+        std::process::exit(1);
+    }
+    let url = &args[1];
+
+    let url_hash = fetch_url_hash(url)?;
+    if cached_hash(url)?.as_ref().map(|hash| hash.as_str()) != Some(&url_hash) {
+        let status = std::process::Command::new(&args[2])
+            .args(&args[3..])
+            .status()?;
+
+        if status.success() {
+            let path = cached_path(url);
+            if let Some(parent) = path.parent() {
+                if !parent.exists() {
+                    std::fs::create_dir_all(&parent)?;
+                }
+            }
+            std::fs::write(&cached_path(url), format!("{}\n", url_hash).as_bytes())?;
+        } else {
+            std::process::exit(status.code().unwrap_or(1));
+        }
+    } else {
+        eprintln!("content at {} didn't change, aborting", url);
+    }
+
+    Ok(())
+}

--- a/secrets.toml.example
+++ b/secrets.toml.example
@@ -31,6 +31,10 @@ regex = "sekrit"
 hostname = "buildbot.rust-lang.org"
 email = "admin@rust-lang.org"
 
+# Used to synchronize mailing lists
+[mailgun]
+token = "mailgun"
+
 # Distribution pieces used to configure releases.
 [dist]
 

--- a/sync-mailgun/Cargo.toml
+++ b/sync-mailgun/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sync-mailgun"
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = '2018'
+
+[dependencies]
+curl = "0.4"
+failure = "0.1"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+log = "0.4"
+env_logger = { version = "0.5", default-features = false }
+rust_team_data = { git = "https://github.com/rust-lang/team" }

--- a/sync-mailgun/src/main.rs
+++ b/sync-mailgun/src/main.rs
@@ -1,0 +1,291 @@
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::str;
+
+use curl::easy::{Easy, Form};
+use failure::{bail, format_err, Error, ResultExt};
+use rust_team_data::v1 as team_data;
+
+const DESCRIPTION: &str = "managed by an automatic script on github";
+
+mod api {
+    #[derive(serde_derive::Deserialize)]
+    pub struct ListResponse {
+        pub items: Vec<List>,
+        pub paging: Paging,
+    }
+
+    #[derive(serde_derive::Deserialize)]
+    pub struct RoutesResponse {
+        pub items: Vec<Route>,
+        pub total_count: usize,
+    }
+    #[derive(serde_derive::Deserialize)]
+    pub struct Route {
+        pub actions: Vec<String>,
+        pub expression: String,
+        pub id: String,
+        pub description: serde_json::Value,
+    }
+
+    #[derive(serde_derive::Deserialize)]
+    pub struct List {
+        pub access_level: String,
+        pub address: String,
+        pub members_count: u64,
+    }
+
+    #[derive(serde_derive::Deserialize)]
+    pub struct Paging {
+        pub first: String,
+        pub last: String,
+        pub next: String,
+        pub previous: String,
+    }
+
+    #[derive(serde_derive::Deserialize)]
+    pub struct MembersResponse {
+        pub items: Vec<Member>,
+        pub paging: Paging,
+    }
+
+    #[derive(serde_derive::Deserialize)]
+    pub struct Member {
+        pub address: String,
+    }
+}
+
+#[derive(serde_derive::Deserialize)]
+struct Empty {}
+
+fn main() {
+    env_logger::init();
+    if let Err(e) = run() {
+        eprintln!("error: {}", e);
+        for e in e.iter_causes() {
+            eprintln!("  cause: {}", e);
+        }
+        std::process::exit(1);
+    }
+}
+
+fn mangle_address(addr: &str) -> Result<String, Error> {
+    // Escape dots since they have a special meaning in Python regexes
+    let mangled = addr.replace(".", "\\.");
+
+    // Inject (?:\+.+)? before the '@' in the address to support '+' aliases like
+    // infra+botname@rust-lang.org
+    if let Some(at_pos) = mangled.find('@') {
+        let (user, domain) = mangled.split_at(at_pos);
+        Ok(format!("^{}(?:\\+.+)?{}$", user, domain))
+    } else {
+        bail!("the address `{}` doesn't have any '@'", addr);
+    }
+}
+
+fn run() -> Result<(), Error> {
+    let api_url = if let Ok(url) = std::env::var("TEAM_DATA_BASE_URL") {
+        format!("{}/lists.json", url)
+    } else {
+        format!("{}/lists.json", team_data::BASE_URL)
+    };
+    let mut mailmap = get::<team_data::Lists>(&api_url)?;
+
+    // Mangle all the mailing list addresses
+    for list in mailmap.lists.values_mut() {
+        list.address = mangle_address(&list.address)?;
+    }
+
+    let mut routes = Vec::new();
+    let mut response = get::<api::RoutesResponse>("/routes")?;
+    let mut cur = 0;
+    while response.items.len() > 0 {
+        cur += response.items.len();
+        routes.extend(response.items);
+        if cur >= response.total_count {
+            break
+        }
+        let url = format!("/routes?skip={}", cur);
+        response = get::<api::RoutesResponse>(&url)?;
+    }
+
+    let mut addr2list = HashMap::new();
+    for list in mailmap.lists.values() {
+        if addr2list.insert(&list.address[..], list).is_some() {
+            bail!("duplicate address: {}", list.address);
+        }
+    }
+
+    for route in routes {
+        if route.description != DESCRIPTION {
+            continue
+        }
+        let address = extract(&route.expression, "match_recipient(\"", "\")");
+        match addr2list.remove(address) {
+            Some(new_list) => {
+                sync(&route, &new_list)
+                    .with_context(|_| format!("failed to sync {}", address))?
+            }
+            None => {
+                del(&route)
+                    .with_context(|_| format!("failed to delete {}", address))?
+            }
+        }
+    }
+
+    for (_, list) in addr2list.iter() {
+        create(list)
+            .with_context(|_| format!("failed to create {}", list.address))?;
+    }
+
+    Ok(())
+}
+
+fn create(new: &team_data::List) -> Result<(), Error> {
+    let mut form = Form::new();
+    form.part("priority").contents(b"0").add()?;
+    form.part("description").contents(DESCRIPTION.as_bytes()).add()?;
+    let expr = format!("match_recipient(\"{}\")", new.address);
+    form.part("expression").contents(expr.as_bytes()).add()?;
+    for member in new.members.iter() {
+        form.part("action").contents(format!("forward(\"{}\")", member).as_bytes()).add()?;
+    }
+    post::<Empty>("/routes", form)?;
+
+    Ok(())
+}
+
+fn sync(route: &api::Route, list: &team_data::List) -> Result<(), Error> {
+    let before = route
+        .actions
+        .iter()
+        .map(|action| extract(action, "forward(\"", "\")"))
+        .collect::<HashSet<_>>();
+    let after = list.members.iter().map(|s| &s[..]).collect::<HashSet<_>>();
+    if before == after {
+        return Ok(())
+    }
+
+    let mut form = Form::new();
+    for member in list.members.iter() {
+        form.part("action").contents(format!("forward(\"{}\")", member).as_bytes()).add()?;
+    }
+    put::<Empty>(&format!("/routes/{}", route.id), form)?;
+
+    Ok(())
+}
+
+fn del(route: &api::Route) -> Result<(), Error> {
+    delete::<Empty>(&format!("/routes/{}", route.id))?;
+    Ok(())
+}
+
+fn get<T: for<'de> serde::Deserialize<'de>>(url: &str) -> Result<T, Error> {
+    execute(url, Method::Get)
+}
+
+fn post<T: for<'de> serde::Deserialize<'de>>(
+    url: &str,
+    form: Form,
+) -> Result<T, Error> {
+    execute(url, Method::Post(form))
+}
+
+fn put<T: for<'de> serde::Deserialize<'de>>(
+    url: &str,
+    form: Form,
+) -> Result<T, Error> {
+    execute(url, Method::Put(form))
+}
+
+fn delete<T: for<'de> serde::Deserialize<'de>>(url: &str) -> Result<T, Error> {
+    execute(url, Method::Delete)
+}
+
+enum Method {
+    Get,
+    Delete,
+    Post(Form),
+    Put(Form),
+}
+
+fn execute<T: for<'de> serde::Deserialize<'de>>(
+    url: &str,
+    method: Method,
+) -> Result<T, Error> {
+    thread_local!(static HANDLE: RefCell<Easy> = RefCell::new(Easy::new()));
+    let password = env::var("MAILGUN_API_TOKEN")
+        .map_err(|_| format_err!("must set $MAILGUN_API_TOKEN"))?;
+    let result = HANDLE.with(|handle| {
+        let mut handle = handle.borrow_mut();
+        handle.reset();
+        let url = if url.starts_with("http://") || url.starts_with("https://") {
+            url.to_string()
+        } else {
+            format!("https://api.mailgun.net/v3{}", url)
+        };
+        handle.url(&url)?;
+        match method {
+            Method::Get => {
+                log::debug!("GET {}", url);
+                handle.get(true)?;
+            }
+            Method::Delete => {
+                log::debug!("DELETE {}", url);
+                handle.custom_request("DELETE")?;
+            }
+            Method::Post(form) => {
+                log::debug!("POST {}", url);
+                handle.httppost(form)?;
+            }
+            Method::Put(form) => {
+                log::debug!("PUT {}", url);
+                handle.httppost(form)?;
+                handle.custom_request("PUT")?;
+            }
+        }
+        // Add the API key only for Mailgun requests
+        if url.starts_with("https://api.mailgun.net") {
+            handle.username("api")?;
+            handle.password(&password)?;
+        }
+        handle.useragent("rust-lang/rust membership update")?;
+        // handle.verbose(true)?;
+        let mut result = Vec::new();
+        let mut headers = Vec::new();
+        {
+            let mut transfer = handle.transfer();
+            transfer.write_function(|data| {
+                result.extend_from_slice(data);
+                Ok(data.len())
+            })?;
+            transfer.header_function(|header| {
+                if let Ok(s) = str::from_utf8(header) {
+                    headers.push(s.to_string());
+                }
+                true
+            })?;
+            transfer.perform()?;
+        }
+
+        let result = String::from_utf8(result)
+            .map_err(|_| format_err!("response was invalid utf-8"))?;
+
+        log::trace!("headers: {:#?}", headers);
+        log::trace!("json: {}", result);
+        let code = handle.response_code()?;
+        if code != 200 {
+            bail!("failed to get a 200 code, got {}\n\n{}", code, result)
+        }
+        Ok(serde_json::from_str(&result)
+            .with_context(|_| "failed to parse json response")?)
+    });
+    Ok(result.with_context(|_| format!("failed to send request to {}", url))?)
+}
+
+fn extract<'a>(s: &'a str, prefix: &str, suffix: &str) -> &'a str {
+    assert!(s.starts_with(prefix), "`{}` didn't start with `{}`", s, prefix);
+    assert!(s.ends_with(suffix), "`{}` didn't end with `{}`", s, suffix);
+    &s[prefix.len()..s.len() - suffix.len()]
+}


### PR DESCRIPTION
This PR adds a cronjob to RCS to automatically synchronize mailing lists with the team repository. I added two binaries:

* `run-on-change`: a simple binary that stores the hash of a web page and executes the program only when that hash changes. This allows to run the cron frequently (every 5 minutes) without hammering the Mailgun API needlessly.
* `sync-mailgun`: a copy of the binary from the `mailgun-mailmap` repository with the changes needed to fetch the data from the team repo.

I chose to import the mailgun script in this repo instead of adding it as a submodule since that's an overkill for a single file. We can archive the `mailgun-mailmap` repo once this is merged.

All the changes to the mailing lists have been approved by the team leads.
r? @alexcrichton 