### PR TITLE
Update name of cirrus libc task

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -148,7 +148,7 @@ name = "Travis CI - Branch"
 [repo.libc.status.appveyor]
 context = "continuous-integration/appveyor/branch"
 [repo.libc.checks.cirrus]
-name = "stable x86_64-unknown-freebsd"
+name = "stable x86_64-unknown-freebsd-11"
 
 [repo.rustup-rs]
 owner = "rust-lang"

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -147,8 +147,10 @@ secret = "{{ homu.repo-secrets.libc }}"
 name = "Travis CI - Branch"
 [repo.libc.status.appveyor]
 context = "continuous-integration/appveyor/branch"
-[repo.libc.checks.cirrus]
+[repo.libc.checks.cirrus-freebsd-11]
 name = "stable x86_64-unknown-freebsd-11"
+[repo.libc.checks.cirrus-freebsd-12]
+name = "nightly x86_64-unknown-freebsd-12"
 
 [repo.rustup-rs]
 owner = "rust-lang"


### PR DESCRIPTION
cc @asomers 

---

cc @pietroalbini - we have 2 cirrus tasks in libc right now - do you know what would be the right way of adding a second one here? Can I just add a second `name = "nightly x86_64-unknown-freebsd-12"` line ?