### PR TITLE
add miri to homu

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -345,3 +345,20 @@ auto = "auto"
 secret = "{{ homu.repo-secrets.hashbrown }}"
 [repo.hashbrown.checks.travis]
 name = "Travis CI - Branch"
+
+[repo.miri]
+owner = "rust-lang"
+name = "miri"
+timeout = 5400
+
+# Permissions managed through rust-lang/team
+rust_team = true
+reviewers = []
+try_users = []
+
+[repo.miri.branch]
+auto = "auto"
+[repo.miri.github]
+secret = "{{ homu.repo-secrets.miri }}"
+[repo.miri.checks.travis]
+name = "Travis CI - Branch"


### PR DESCRIPTION
I hope I did this right. Also see https://github.com/rust-lang/team/pull/76.

What needs to happen for `homu.repo-secrets.miri` to be a thing?

Cc @oli-obk 