### PR TITLE
Miri also has AppVeyor CI

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -362,3 +362,5 @@ auto = "auto"
 secret = "{{ homu.repo-secrets.miri }}"
 [repo.miri.checks.travis]
 name = "Travis CI - Branch"
+[repo.miri.status.appveyor]
+context = "continuous-integration/appveyor/branch"


### PR DESCRIPTION
Is that the right way to configure bors to require AppVeyor to pass?