### PR TITLE
cancelbot: only cancel azure jobs when the job itself fails

### DIFF
--- a/cancelbot/src/azure.rs
+++ b/cancelbot/src/azure.rs
@@ -31,4 +31,5 @@ pub struct Timeline {
 pub struct Record {
     pub name: String,
     pub result: String,
+    pub r#type: String,
 }

--- a/cancelbot/src/main.rs
+++ b/cancelbot/src/main.rs
@@ -361,7 +361,7 @@ impl State {
                 let me2 = me.clone();
                 let build = build.clone();
                 let cancel_first = timeline.and_then(move |list: azure::Timeline| {
-                    if list.records.iter().any(|r| r.result == "failed") {
+                    if list.records.iter().any(|r| r.result == "failed" && r.r#type == "Job") {
                         me2.azure_cancel_build(&repo3, &build)
                     } else {
                         Box::new(futures::future::ok(()))


### PR DESCRIPTION
The previous code was cancelling all builds when any task failed. In our configuration though we have tasks that are allowed to fail without impacting the job outcome (like CPU usage stats uploading), and the previous code would've cancelled an otherwise green build.

This commit filters the timeline records we check to only look at full jobs instead of single tasks.

r? @alexcrichton 