### PR TITLE
increase miri CI timeout

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -353,7 +353,7 @@ name = "Travis CI - Branch"
 [repo.miri]
 owner = "rust-lang"
 name = "miri"
-timeout = 5400
+timeout = 7200
 
 # Permissions managed through rust-lang/team
 rust_team = true


### PR DESCRIPTION
Yesterday we ran into this timeout not because our CI took long, but because we had to wait for >1h to even get any AppVeyor CI slot.

See https://github.com/rust-lang/miri/pull/816 for an example.