### PR TITLE
remove regex config

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -198,26 +198,6 @@ name = "Travis CI - Branch"
 context = "continuous-integration/appveyor/branch"
 
 
-[repo.regex]
-owner = "rust-lang"
-name = "regex"
-timeout = 5400
-
-# Permissions managed through rust-lang/team
-rust_team = true
-reviewers = []
-try_users = []
-
-[repo.regex.branch]
-auto = "auto"
-[repo.regex.github]
-secret = "{{ homu.repo-secrets.regex }}"
-[repo.regex.checks.travis]
-name = "Travis CI - Branch"
-[repo.regex.status.appveyor]
-context = "continuous-integration/appveyor/branch"
-
-
 [repo.crater]
 owner = "rust-lang-nursery"
 name = "crater"


### PR DESCRIPTION
The regex crate stopped using bors a long time ago. At that point, bors
would take quite a long time and would occasionally get stuck. Given
that regex's very low traffic volume, it just wasn't worth having.
Moreover, it wasn't clear how or if bors could be used in a way that
avoided merge commits.

In any case, back in those days, turning off bors meant asking Alex to
do it, but it looks like the config got carried into this repo, which I
did not know existed until @RalfJung pointed it out to me:
https://github.com/rust-lang/regex/commit/2b4ac35ef9d2c8db81ca46fba0503acf4b920303#commitcomment-34142130