### PR TITLE
Migrate libc to Azure Pipelines

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -141,8 +141,8 @@ auto = "auto-libc"
 [repo.libc.github]
 secret = "{{ homu.repo-secrets.libc }}"
 
-[repo.libc.checks.travis]
-name = "Travis CI - Branch"
+[repo.libc.checks.azure]
+name = "Azure Pipelines"
 [repo.libc.status.appveyor]
 context = "continuous-integration/appveyor/branch"
 [repo.libc.checks.cirrus-freebsd-11]

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -142,7 +142,7 @@ auto = "auto-libc"
 secret = "{{ homu.repo-secrets.libc }}"
 
 [repo.libc.checks.azure]
-name = "Azure Pipelines"
+name = "rust-lang.libc"
 [repo.libc.status.appveyor]
 context = "continuous-integration/appveyor/branch"
 [repo.libc.checks.cirrus-freebsd-11]


### PR DESCRIPTION
See accompanying libc PR: https://github.com/rust-lang/libc/pull/1376

I'm not sure which name should the check have. cc @alexcrichton 