### PR TITLE
stdarch should use status instead of check

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -159,8 +159,8 @@ try_users = []
 [repo.stdarch.github]
 secret = "{{ homu.repo-secrets.stdarch }}"
 
-[repo.stdarch.checks.azure]
-name = "rust-lang.stdarch"
+[repo.stdarch.status.azure]
+context = "rust-lang.stdarch"
 [repo.stdarch.checks.cirrus-freebsd]
 name = "x86_64-unknown-freebsd"
 


### PR DESCRIPTION
This updates `stdarch` to use `status` instead of `check` like `libc` does.