### PR TITLE
Add 15 minutes to the bors timeout...

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -35,7 +35,7 @@ port = 7942
 [repo.rust]
 owner = "rust-lang"
 name = "rust"
-timeout = 14400
+timeout = 15300
 
 # Permissions managed through rust-lang/team
 rust_team = true


### PR DESCRIPTION
...because it is really painful when a PR (e.g., https://github.com/rust-lang/rust/pull/64182#issuecomment-528571560) fails with just one minute after the deadline.

r? @Mark-Simulacrum 