### PR TITLE
promote-release: allow overriding the branch to pull commits from

### DIFF
--- a/promote-release/src/main.rs
+++ b/promote-release/src/main.rs
@@ -54,11 +54,17 @@ impl Context {
     fn run(&mut self) {
         let _lock = self.lock();
         self.update_repo();
-        let branch = match &self.release[..] {
-            "nightly" => "master",
-            "beta" => "beta",
-            "stable" => "stable",
-            _ => panic!("unknown release: {}", self.release),
+
+        let override_var = env::var("PROMOTE_RELEASE_OVERRIDE_BRANCH");
+        let branch = if let Ok(branch) = override_var.as_ref() {
+            branch
+        } else {
+            match &self.release[..] {
+                "nightly" => "master",
+                "beta" => "beta",
+                "stable" => "stable",
+                _ => panic!("unknown release: {}", self.release),
+            }
         };
         self.do_release(branch);
     }


### PR DESCRIPTION
While this is not needed for the production builds, it might be useful to publish try builds on dev-static as nightlies, for example to test how rustup would behave with a manifest change.

This commit adds a `PROMOTE_RELEASE_OVERRIDE_BRANCH` environment variable that allows the default branch promote-release pulls from to be overridden. When the environment variable is not present the current behavior will not change.

On the release team side, a nightly build from the `promote-tmp` branch could be published to dev-static with this command on RCS:

```
docker exec -d -it rcs bash -c 'PROMOTE_RELEASE_OVERRIDE_BRANCH=promote-tmp promote-release /tmp/nightly-tmp nightly /data/secrets-dev.toml 2>&1 | logger --tag release-nightly-tmp'
```

I'll add the command on the forge once the PR is merged.

r? @Mark-Simulacrum 
cc https://github.com/rust-lang/rust/pull/64823#issuecomment-538554386