### PR TITLE
Add GHA checks for the Clippy Repo

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -239,10 +239,6 @@ try_users = []
 auto = "auto"
 [repo.clippy.github]
 secret = "{{ homu.repo-secrets.clippy }}"
-[repo.clippy.checks.travis]
-name = "Travis CI - Branch"
-[repo.clippy.status.appveyor]
-context = "continuous-integration/appveyor/branch"
 [repo.clippy.checks.action_test]
 name = "bors test finished"
 [repo.clippy.checks.action_dev_test]

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -243,6 +243,12 @@ secret = "{{ homu.repo-secrets.clippy }}"
 name = "Travis CI - Branch"
 [repo.clippy.status.appveyor]
 context = "continuous-integration/appveyor/branch"
+[repo.clippy.checks.action_test]
+name = "bors test finished"
+[repo.clippy.checks.action_dev_test]
+name = "bors dev test finished"
+[repo.clippy.checks.action_remark_test]
+name = "bors remark test finished"
 
 [repo.rls]
 owner = "rust-lang"


### PR DESCRIPTION
This adds 3 checks for the Clippy repos move to GHA. The dummy jobs for bors, are added in https://github.com/rust-lang/rust-clippy/pull/5088/commits/1a83b7ad7a45aa8db4db7da55a45931e725a1ca3. This is split up in 3 different jobs, because we run the `remark` and the `dev` (both take <\~1min) checks also on PRs, but the `bors test` (15\~17min, across 21 dependent jobs, with a limit of 10 jobs at a time) only on `bors` builds.

r? @pietroalbini 

Is there anything else to do, to get GHA to work with bors?

---
~~Clippy is currently in the Test phase of GHA. Until then we want to only gate on Travis+AppVeyor, as suggested by @pietroalbini~~ We're ready to move https://github.com/rust-lang/rust-clippy/pull/5190