### PR TITLE
Configure alias for buildbot2.rust-lang.org

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -26,7 +26,7 @@ if [ -z "$DEV" ]; then
         --agree-tos \
         -m `tq nginx.email < $secrets` \
         -w /usr/share/nginx/html \
-        -d `tq nginx.hostname < $secrets`
+        -d `tq nginx.hostname < $secrets`,`tq nginx.hostname_alias < $secrets`
 
     nginx -s stop
   fi

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -38,7 +38,7 @@ http {
 
     add_header Strict-Transport-Security max-age=15768000;
 
-    server_name  {{ nginx.hostname }};
+    server_name  {{ nginx.hostname }} {{ nginx.hostname_alias }};
 
     access_log  /var/log/nginx/{{ nginx.hostname }}.access.log;
 
@@ -54,7 +54,7 @@ http {
 
   server {
     listen 80;
-    server_name {{ nginx.hostname }};
+    server_name {{ nginx.hostname }} {{ nginx.hostname_alias }};
     return 301 https://$host$request_uri;
   }
 }

--- a/secrets.toml.example
+++ b/secrets.toml.example
@@ -29,6 +29,7 @@ stdarch = "sekrit"
 # Used to fetch a cert from letsencrypt
 [nginx]
 hostname = "buildbot.rust-lang.org"
+hostname_alias = "bors.rust-lang.org"
 email = "admin@rust-lang.org"
 
 # Used to synchronize mailing lists


### PR DESCRIPTION
I've already set up bors.rust-lang.org to point at buildbot2.rust-lang.org via CNAME; I suspect we'll probably want to keep buildbot2 around for while (if not indefinitely) but a new name seems reasonable for now too.

r? @pietroalbini 