### PR TITLE
Fix broken Mailgun synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,6 +1465,7 @@ dependencies = [
  "curl 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sync-mailgun/Cargo.toml
+++ b/sync-mailgun/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = "1"
 log = "0.4"
 env_logger = { version = "0.5", default-features = false }
 rust_team_data = { git = "https://github.com/rust-lang/team" }
+
+[dev-dependencies]
+indexmap = "1"

--- a/sync-mailgun/src/api.rs
+++ b/sync-mailgun/src/api.rs
@@ -1,0 +1,47 @@
+#[derive(serde_derive::Deserialize)]
+pub struct ListResponse {
+    pub items: Vec<List>,
+    pub paging: Paging,
+}
+
+#[derive(serde_derive::Deserialize)]
+pub struct RoutesResponse {
+    pub items: Vec<Route>,
+    pub total_count: usize,
+}
+#[derive(serde_derive::Deserialize)]
+pub struct Route {
+    pub actions: Vec<String>,
+    pub expression: String,
+    pub id: String,
+    pub description: serde_json::Value,
+}
+
+#[derive(serde_derive::Deserialize)]
+pub struct List {
+    pub access_level: String,
+    pub address: String,
+    pub members_count: u64,
+}
+
+#[derive(serde_derive::Deserialize)]
+pub struct Paging {
+    pub first: String,
+    pub last: String,
+    pub next: String,
+    pub previous: String,
+}
+
+#[derive(serde_derive::Deserialize)]
+pub struct MembersResponse {
+    pub items: Vec<Member>,
+    pub paging: Paging,
+}
+
+#[derive(serde_derive::Deserialize)]
+pub struct Member {
+    pub address: String,
+}
+
+#[derive(serde_derive::Deserialize)]
+pub struct Empty {}

--- a/sync-mailgun/src/api.rs
+++ b/sync-mailgun/src/api.rs
@@ -14,6 +14,7 @@ pub struct Route {
     pub actions: Vec<String>,
     pub expression: String,
     pub id: String,
+    pub priority: i32,
     pub description: serde_json::Value,
 }
 

--- a/sync-mailgun/src/http.rs
+++ b/sync-mailgun/src/http.rs
@@ -1,0 +1,109 @@
+use std::cell::RefCell;
+use std::env;
+use std::str;
+
+use curl::easy::{Easy, Form};
+use failure::{bail, format_err, Error, ResultExt};
+
+pub fn get<T: for<'de> serde::Deserialize<'de>>(url: &str) -> Result<T, Error> {
+    execute(url, Method::Get)
+}
+
+pub fn post<T: for<'de> serde::Deserialize<'de>>(
+    url: &str,
+    form: Form,
+) -> Result<T, Error> {
+    execute(url, Method::Post(form))
+}
+
+pub fn put<T: for<'de> serde::Deserialize<'de>>(
+    url: &str,
+    form: Form,
+) -> Result<T, Error> {
+    execute(url, Method::Put(form))
+}
+
+pub fn delete<T: for<'de> serde::Deserialize<'de>>(url: &str) -> Result<T, Error> {
+    execute(url, Method::Delete)
+}
+
+pub enum Method {
+    Get,
+    Delete,
+    Post(Form),
+    Put(Form),
+}
+
+fn execute<T: for<'de> serde::Deserialize<'de>>(
+    url: &str,
+    method: Method,
+) -> Result<T, Error> {
+    thread_local!(static HANDLE: RefCell<Easy> = RefCell::new(Easy::new()));
+    let password = env::var("MAILGUN_API_TOKEN")
+        .map_err(|_| format_err!("must set $MAILGUN_API_TOKEN"))?;
+    let result = HANDLE.with(|handle| {
+        let mut handle = handle.borrow_mut();
+        handle.reset();
+        let url = if url.starts_with("http://") || url.starts_with("https://") {
+            url.to_string()
+        } else {
+            format!("https://api.mailgun.net/v3{}", url)
+        };
+        handle.url(&url)?;
+        match method {
+            Method::Get => {
+                log::debug!("GET {}", url);
+                handle.get(true)?;
+            }
+            Method::Delete => {
+                log::debug!("DELETE {}", url);
+                handle.custom_request("DELETE")?;
+            }
+            Method::Post(form) => {
+                log::debug!("POST {}", url);
+                handle.httppost(form)?;
+            }
+            Method::Put(form) => {
+                log::debug!("PUT {}", url);
+                handle.httppost(form)?;
+                handle.custom_request("PUT")?;
+            }
+        }
+        // Add the API key only for Mailgun requests
+        if url.starts_with("https://api.mailgun.net") {
+            handle.username("api")?;
+            handle.password(&password)?;
+        }
+        handle.useragent("rust-lang/rust membership update")?;
+        // handle.verbose(true)?;
+        let mut result = Vec::new();
+        let mut headers = Vec::new();
+        {
+            let mut transfer = handle.transfer();
+            transfer.write_function(|data| {
+                result.extend_from_slice(data);
+                Ok(data.len())
+            })?;
+            transfer.header_function(|header| {
+                if let Ok(s) = str::from_utf8(header) {
+                    headers.push(s.to_string());
+                }
+                true
+            })?;
+            transfer.perform()?;
+        }
+
+        let result = String::from_utf8(result)
+            .map_err(|_| format_err!("response was invalid utf-8"))?;
+
+        log::trace!("headers: {:#?}", headers);
+        log::trace!("json: {}", result);
+        let code = handle.response_code()?;
+        if code != 200 {
+            bail!("failed to get a 200 code, got {}\n\n{}", code, result)
+        }
+        Ok(serde_json::from_str(&result)
+            .with_context(|_| "failed to parse json response")?)
+    });
+    Ok(result.with_context(|_| format!("failed to send request to {}", url))?)
+}

--- a/sync-mailgun/src/main.rs
+++ b/sync-mailgun/src/main.rs
@@ -32,7 +32,7 @@ struct List {
     priority: i32,
 }
 
-fn mangle_lists(mut lists: team_data::Lists) -> Result<Vec<List>, Error> {
+fn mangle_lists(lists: team_data::Lists) -> Result<Vec<List>, Error> {
     let mut result = Vec::new();
 
     for (_key, list) in lists.lists.into_iter() {

--- a/sync-mailgun/src/main.rs
+++ b/sync-mailgun/src/main.rs
@@ -1,63 +1,16 @@
+mod api;
+
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::str;
 
+use crate::api::Empty;
 use curl::easy::{Easy, Form};
 use failure::{bail, format_err, Error, ResultExt};
 use rust_team_data::v1 as team_data;
 
 const DESCRIPTION: &str = "managed by an automatic script on github";
-
-mod api {
-    #[derive(serde_derive::Deserialize)]
-    pub struct ListResponse {
-        pub items: Vec<List>,
-        pub paging: Paging,
-    }
-
-    #[derive(serde_derive::Deserialize)]
-    pub struct RoutesResponse {
-        pub items: Vec<Route>,
-        pub total_count: usize,
-    }
-    #[derive(serde_derive::Deserialize)]
-    pub struct Route {
-        pub actions: Vec<String>,
-        pub expression: String,
-        pub id: String,
-        pub description: serde_json::Value,
-    }
-
-    #[derive(serde_derive::Deserialize)]
-    pub struct List {
-        pub access_level: String,
-        pub address: String,
-        pub members_count: u64,
-    }
-
-    #[derive(serde_derive::Deserialize)]
-    pub struct Paging {
-        pub first: String,
-        pub last: String,
-        pub next: String,
-        pub previous: String,
-    }
-
-    #[derive(serde_derive::Deserialize)]
-    pub struct MembersResponse {
-        pub items: Vec<Member>,
-        pub paging: Paging,
-    }
-
-    #[derive(serde_derive::Deserialize)]
-    pub struct Member {
-        pub address: String,
-    }
-}
-
-#[derive(serde_derive::Deserialize)]
-struct Empty {}
 
 fn main() {
     env_logger::init();

--- a/sync-mailgun/src/main.rs
+++ b/sync-mailgun/src/main.rs
@@ -164,4 +164,13 @@ mod tests {
             "forward(\"baz@example.net\")",
         ], build_route_actions(&list).collect::<Vec<_>>());
     }
+
+    #[test]
+    fn test_mangle_address() {
+        assert_eq!(
+            r"^list-name(?:\+.+)?@example\.com$",
+            mangle_address("list-name@example.com").unwrap()
+        );
+        assert!(mangle_address("list-name.example.com").is_err());
+    }
 }

--- a/sync-mailgun/src/main.rs
+++ b/sync-mailgun/src/main.rs
@@ -35,7 +35,7 @@ struct List {
 fn mangle_lists(mut lists: team_data::Lists) -> Result<Vec<List>, Error> {
     let mut result = Vec::new();
 
-    for (_key, list) in lists.lists.drain(..) {
+    for (_key, list) in lists.lists.into_iter() {
         let base_list = List {
             address: mangle_address(&list.address)?,
             members: Vec::new(),

--- a/sync-mailgun/src/main.rs
+++ b/sync-mailgun/src/main.rs
@@ -11,6 +11,9 @@ use rust_team_data::v1 as team_data;
 
 const DESCRIPTION: &str = "managed by an automatic script on github";
 
+// Limit (in bytes) of the size of a Mailgun rule's actions list.
+const ACTIONS_SIZE_LIMIT_BYTES: usize = 4000;
+
 fn main() {
     env_logger::init();
     if let Err(e) = run() {
@@ -20,6 +23,58 @@ fn main() {
         }
         std::process::exit(1);
     }
+}
+
+#[derive(Debug, Clone)]
+struct List {
+    address: String,
+    members: Vec<String>,
+    priority: i32,
+}
+
+fn mangle_lists(mut lists: team_data::Lists) -> Result<Vec<List>, Error> {
+    let mut result = Vec::new();
+
+    for (_key, list) in lists.lists.drain(..) {
+        let base_list = List {
+            address: mangle_address(&list.address)?,
+            members: Vec::new(),
+            priority: 0,
+        };
+
+        // Mailgun only supports at most 4000 bytes of "actions" for each rule, and some of our
+        // lists have so many members we're going over that limit.
+        //
+        // The official workaround for this, as explained in the docs [1], is to create multiple
+        // rules, all with the same filter but each with a different set of actions. This snippet
+        // of code implements that.
+        //
+        // Since all the lists have the same address, to differentiate them during the sync this
+        // also sets the priority of the rule to the partition number.
+        //
+        // [1] https://documentation.mailgun.com/en/latest/user_manual.html#routes
+        let mut current_list = base_list.clone();
+        let mut current_actions_len = 0;
+        let mut partitions_count = 0;
+        for member in list.members {
+            let action = build_route_action(&member);
+            if current_actions_len + action.len() > ACTIONS_SIZE_LIMIT_BYTES {
+                partitions_count += 1;
+                result.push(current_list);
+
+                current_list = base_list.clone();
+                current_list.priority = partitions_count;
+                current_actions_len = 0;
+            }
+
+            current_actions_len += action.len();
+            current_list.members.push(member);
+        }
+
+        result.push(current_list);
+    }
+
+    Ok(result)
 }
 
 fn mangle_address(addr: &str) -> Result<String, Error> {
@@ -42,12 +97,10 @@ fn run() -> Result<(), Error> {
     } else {
         format!("{}/lists.json", team_data::BASE_URL)
     };
-    let mut mailmap = http::get::<team_data::Lists>(&api_url)?;
+    let mailmap = http::get::<team_data::Lists>(&api_url)?;
 
-    // Mangle all the mailing list addresses
-    for list in mailmap.lists.values_mut() {
-        list.address = mangle_address(&list.address)?;
-    }
+    // Mangle all the mailing lists
+    let lists = mangle_lists(mailmap)?;
 
     let mut routes = Vec::new();
     let mut response = http::get::<api::RoutesResponse>("/routes")?;
@@ -63,9 +116,9 @@ fn run() -> Result<(), Error> {
     }
 
     let mut addr2list = HashMap::new();
-    for list in mailmap.lists.values() {
-        if addr2list.insert(&list.address[..], list).is_some() {
-            bail!("duplicate address: {}", list.address);
+    for list in &lists {
+        if addr2list.insert((list.address.clone(), list.priority), list).is_some() {
+            bail!("duplicate address: {} (with priority {})", list.address, list.priority);
         }
     }
 
@@ -74,7 +127,8 @@ fn run() -> Result<(), Error> {
             continue
         }
         let address = extract(&route.expression, "match_recipient(\"", "\")");
-        match addr2list.remove(address) {
+        let key = (address.to_string(), route.priority);
+        match addr2list.remove(&key) {
             Some(new_list) => {
                 sync(&route, &new_list)
                     .with_context(|_| format!("failed to sync {}", address))?
@@ -94,13 +148,17 @@ fn run() -> Result<(), Error> {
     Ok(())
 }
 
-fn build_route_actions(list: &team_data::List) -> impl Iterator<Item = String> + '_ {
-    list.members.iter().map(|member| format!("forward(\"{}\")", member))
+fn build_route_action(member: &str) -> String {
+    format!("forward(\"{}\")", member)
 }
 
-fn create(new: &team_data::List) -> Result<(), Error> {
+fn build_route_actions(list: &List) -> impl Iterator<Item = String> + '_ {
+    list.members.iter().map(|member| build_route_action(member))
+}
+
+fn create(new: &List) -> Result<(), Error> {
     let mut form = Form::new();
-    form.part("priority").contents(b"0").add()?;
+    form.part("priority").contents(new.priority.to_string().as_bytes()).add()?;
     form.part("description").contents(DESCRIPTION.as_bytes()).add()?;
     let expr = format!("match_recipient(\"{}\")", new.address);
     form.part("expression").contents(expr.as_bytes()).add()?;
@@ -112,7 +170,7 @@ fn create(new: &team_data::List) -> Result<(), Error> {
     Ok(())
 }
 
-fn sync(route: &api::Route, list: &team_data::List) -> Result<(), Error> {
+fn sync(route: &api::Route, list: &List) -> Result<(), Error> {
     let before = route
         .actions
         .iter()
@@ -124,6 +182,7 @@ fn sync(route: &api::Route, list: &team_data::List) -> Result<(), Error> {
     }
 
     let mut form = Form::new();
+    form.part("priority").contents(list.priority.to_string().as_bytes()).add()?;
     for action in build_route_actions(list) {
         form.part("action").contents(action.as_bytes()).add()?;
     }
@@ -149,13 +208,14 @@ mod tests {
 
     #[test]
     fn test_build_route_actions() {
-        let list = team_data::List {
+        let list = List {
             address: "list@example.com".into(),
             members: vec![
                 "foo@example.com".into(),
                 "bar@example.com".into(),
                 "baz@example.net".into(),
             ],
+            priority: 0,
         };
 
         assert_eq!(vec![
@@ -172,5 +232,64 @@ mod tests {
             mangle_address("list-name@example.com").unwrap()
         );
         assert!(mangle_address("list-name.example.com").is_err());
+    }
+
+    #[test]
+    fn test_mangle_lists() {
+        let original = rust_team_data::v1::Lists {
+            lists: indexmap::indexmap![
+                "small@example.com".to_string() => rust_team_data::v1::List {
+                    address: "small@example.com".into(),
+                    members: vec![
+                        "foo@example.com".into(),
+                        "bar@example.com".into(),
+                    ],
+                },
+                "big@example.com".into() => rust_team_data::v1::List {
+                    address: "big@example.com".into(),
+                    // Generate 300 members automatically to simulate a big list, and test whether the
+                    // partitioning mechanism works.
+                    members: (0..300).map(|i| format!("foo{:03}@example.com", i)).collect(),
+                },
+            ],
+        };
+
+        let mangled = mangle_lists(original).unwrap();
+        assert_eq!(4, mangled.len());
+
+        let small = &mangled[0];
+        assert_eq!(small.address, mangle_address("small@example.com").unwrap());
+        assert_eq!(small.priority, 0);
+        assert_eq!(small.members, vec![
+            "foo@example.com",
+            "bar@example.com",
+        ]);
+
+        // With ACTIONS_SIZE_LIMIT_BYTES = 4000, each list can contain at most 137 users named
+        // `fooNNN@example.com`. If the limit is changed the numbers will need to be updated.
+
+        let big_part1 = &mangled[1];
+        assert_eq!(big_part1.address, mangle_address("big@example.com").unwrap());
+        assert_eq!(big_part1.priority, 0);
+        assert_eq!(
+            big_part1.members,
+            (0..137).map(|i| format!("foo{:03}@example.com", i)).collect::<Vec<_>>()
+        );
+
+        let big_part2 = &mangled[2];
+        assert_eq!(big_part2.address, mangle_address("big@example.com").unwrap());
+        assert_eq!(big_part2.priority, 1);
+        assert_eq!(
+            big_part2.members,
+            (137..274).map(|i| format!("foo{:03}@example.com", i)).collect::<Vec<_>>()
+        );
+
+        let big_part3 = &mangled[3];
+        assert_eq!(big_part3.address, mangle_address("big@example.com").unwrap());
+        assert_eq!(big_part3.priority, 2);
+        assert_eq!(
+            big_part3.members,
+            (274..300).map(|i| format!("foo{:03}@example.com", i)).collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/rust-lang/rust-central-station/issues/693 by partitioning across multiple rules the mailing lists with too many members. Along with the fix I moved into different files the API structs definition and the HTTP client, and I added a couple of tests.

I haven't run the new code yet, once it's approved I'll execute it locally with the prod credentials to see if it actually works (as we don't have a staging environment for this, unfortunately).

This PR is meant to be reviewed commit-by-commit.

r? @Mark-Simulacrum 