### PR TITLE
Revert the double-gate on GHA for rustc

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -51,8 +51,6 @@ secret = "{{ homu.repo-secrets.rust }}"
 [repo.rust.checks.azure]
 name = "fork-auto"
 try_name = "fork-try"
-[repo.rust.checks.actions]
-name = "bors build finished"
 
 # Automatic relabeling
 [repo.rust.labels.approved]   # after homu received `r+`


### PR DESCRIPTION
Let's remove the gate on it until https://github.com/rust-lang/rust/issues/71988 is fixed.

r? @Mark-Simulacrum 