### PR TITLE
Double-gate rustc on GHA and Azure

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -51,6 +51,8 @@ secret = "{{ homu.repo-secrets.rust }}"
 [repo.rust.checks.azure]
 name = "fork-auto"
 try_name = "fork-try"
+[repo.rust.checks.actions]
+name = "bors build finished"
 
 # Automatic relabeling
 [repo.rust.labels.approved]   # after homu received `r+`


### PR DESCRIPTION
Since android was fixed, builds started to be consistently green again (including macOS), so I think it's time to try the double gate.

r? @Mark-Simulacrum 