### PR TITLE
Update gate for Cargo PRs

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -105,8 +105,8 @@ try_users = []
 auto = "auto-cargo"
 [repo.cargo.github]
 secret = "{{ homu.repo-secrets.cargo }}"
-[repo.cargo.checks.azure]
-name = "rust-lang.cargo"
+[repo.cargo.checks.actions]
+name = "bors build finished"
 [repo.cargo.labels.approved]   # after homu received `r+`
 remove = ['S-blocked', 'S-waiting-on-author', 'S-waiting-on-bors', 'S-waiting-on-review']
 add = ['S-waiting-on-bors']


### PR DESCRIPTION
Cargo is looking to switch to GitHub Actions so this updates what bors
gates on, to gate with GitHub Actions instead of Azure.