### PR TITLE
configure vscode-rust in homu

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -252,6 +252,21 @@ name = "bors dev test finished"
 [repo.clippy.checks.action_remark_test]
 name = "bors remark test finished"
 
+[repo.vscode-rust]
+owner = "rust-lang"
+name = "vscode-rust"
+timeout = 1800
+
+# Permissions managed through rust-lang/team
+rust_team = true
+reviewers = []
+try_users = []
+
+[repo.vscode-rust.github]
+secret = "{{ homu.repo-secrets.vscode-rust }}"
+[repo.vscode-rust.checks.actions]
+name = "bors build finished"
+
 [repo.rls]
 owner = "rust-lang"
 name = "rls"

--- a/secrets.toml.example
+++ b/secrets.toml.example
@@ -26,6 +26,7 @@ compiler-builtins = "sekrit"
 regex = "sekrit"
 stdarch = "sekrit"
 chalk = "sekrit"
+vscode-rust = "sekrit"
 
 # Used to fetch a cert from letsencrypt
 [nginx]


### PR DESCRIPTION
This attempts to setup bors for the https://github.com/rust-lang/vscode-rust repository, in preparation for the upcoming RLS/rust-analyzer extension merge.

Not sure if adding a secret is necessary here - I imagine we'd have a workflow where manually pushing a tag triggers a CI build and a deploy script pushing the release but that'd be something complementary to bors. Feel free to remove the secret config or let me know if I should remove that, thanks!