### PR TITLE
Add ninja-build to fix nightlies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update -y && \
       file \
       ssmtp \
       locales \
-      zlib1g-dev
+      zlib1g-dev \
+      ninja-build
 
 # Set the system locales
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Upstream Rust currently requires this for dist hash-and-sign, though that's
realistically a bug, we want a quick fix for now.