### PR TITLE
Add GHA checks for Miri repository

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -377,6 +377,8 @@ try_users = []
 auto = "auto"
 [repo.miri.github]
 secret = "{{ homu.repo-secrets.miri }}"
+[repo.miri.checks.actions]
+name = "bors build finished"
 [repo.miri.checks.travis]
 name = "Travis CI - Branch"
 [repo.miri.status.appveyor]


### PR DESCRIPTION
Waiting for https://github.com/rust-lang/miri/pull/1563 merged.