### PR TITLE
Backfill MAJOR.MINOR Rustup channel manifests with a script this time

### DIFF
--- a/bin/backfill-manifests.sh
+++ b/bin/backfill-manifests.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+secrets=/data/secrets.toml
+
+declare minor_versions_with_patch_releases
+
+minor_versions_with_patch_releases[12]=1
+minor_versions_with_patch_releases[15]=1
+minor_versions_with_patch_releases[22]=1
+minor_versions_with_patch_releases[24]=1
+minor_versions_with_patch_releases[26]=2
+minor_versions_with_patch_releases[27]=2
+minor_versions_with_patch_releases[29]=2
+minor_versions_with_patch_releases[30]=1
+minor_versions_with_patch_releases[31]=1
+minor_versions_with_patch_releases[34]=2
+minor_versions_with_patch_releases[41]=1
+minor_versions_with_patch_releases[43]=1
+minor_versions_with_patch_releases[44]=1
+minor_versions_with_patch_releases[45]=2
+
+export AWS_ACCESS_KEY_ID="$(tq dist.aws-access-key-id < $secrets)"
+export AWS_SECRET_ACCESS_KEY="$(tq dist.aws-secret-key < $secrets)"
+
+bucket="$(tq dist.upload-bucket < $secrets)"
+dir="$(tq dist.upload-dir < $secrets)"
+
+for minor in {8..47}
+do
+    if [ ${minor_versions_with_patch_releases[$minor]+_} ]; then
+        last_patch=${minor_versions_with_patch_releases[$minor]};
+    else
+        last_patch=0;
+    fi
+
+    src="s3://${bucket}/${dir}/channel-rust-1.${minor}.${last_patch}.toml"
+    dst="s3://${bucket}/${dir}/channel-rust-1.${minor}.toml"
+
+    aws cp --only-show-errors "${src}" "${dst}"
+    aws cp --only-show-errors "${src}".asc "${dst}".asc
+    aws cp --only-show-errors "${src}".sha256 "${dst}".sha256
+done


### PR DESCRIPTION
This is a replacement for #949 

Now that https://github.com/rust-lang/rust/pull/76107 has been merged,
new releases will also write their manifests to channel-rust-1.x.toml as
well as channel-rust-1.x.y.toml to enable `rustup install 1.48` to get
the latest patch release in a minor release series.

This commit adds an idempotent script to copy manifests and their
signatures for the last patch release in every minor release series to
the corresponding minor manifest files so that past minor versions will
work with the rustup functionality too.

This script should only need to be run once, but should be safe to run
more than once.

It starts at 1.8 because we don't have manifests for 1.0-1.7, and it ends
with 1.47 because 1.48 will be the first stable release to write out the
1.x channel manifest.

r? @pietroalbini <3