### PR TITLE
Listen to GHA on libc instead of Azure

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -147,8 +147,8 @@ auto = "auto-libc"
 [repo.libc.github]
 secret = "{{ homu.repo-secrets.libc }}"
 
-[repo.libc.status.azure]
-context = "rust-lang.libc"
+[repo.libc.checks.actions]
+name = "bors build finished"
 [repo.libc.checks.cirrus-freebsd-10]
 name = "nightly x86_64-unknown-freebsd-10"
 [repo.libc.checks.cirrus-freebsd-11]


### PR DESCRIPTION
This gets bors to listen to GHA on the libc repository.
I think Azure Pipelines can be removed since it seems GHA works as expected. Cirrus CI is still used for FreeBSD targets.

r? @pietroalbini 
