### PR TITLE
Replace FreeBSD 10 with FreeBSD 13 on libc CI

### DIFF
--- a/homu.toml.template
+++ b/homu.toml.template
@@ -149,12 +149,12 @@ secret = "{{ homu.repo-secrets.libc }}"
 
 [repo.libc.checks.actions]
 name = "bors build finished"
-[repo.libc.checks.cirrus-freebsd-10]
-name = "nightly x86_64-unknown-freebsd-10"
 [repo.libc.checks.cirrus-freebsd-11]
 name = "stable x86_64-unknown-freebsd-11"
 [repo.libc.checks.cirrus-freebsd-12]
 name = "nightly x86_64-unknown-freebsd-12"
+[repo.libc.checks.cirrus-freebsd-13]
+name = "nightly x86_64-unknown-freebsd-13"
 
 [repo.stdarch]
 owner = "rust-lang"

--- a/homu.toml.template
+++ b/homu.toml.template
@@ -155,6 +155,12 @@ name = "stable x86_64-unknown-freebsd-11"
 name = "nightly x86_64-unknown-freebsd-12"
 [repo.libc.checks.cirrus-freebsd-13]
 name = "nightly x86_64-unknown-freebsd-13"
+[repo.libc.labels.approved]   # after homu received `r+`
+remove = ['S-blocked', 'S-waiting-on-author', 'S-waiting-on-bors', 'S-waiting-on-review']
+add = ['S-waiting-on-bors']
+[repo.libc.labels.failed]     # test failed (maybe spurious, so fall back to -on-review)
+remove = ['S-blocked', 'S-waiting-on-author', 'S-waiting-on-bors', 'S-waiting-on-review']
+add = ['S-waiting-on-review']
 
 [repo.stdarch]
 owner = "rust-lang"


### PR DESCRIPTION
So, FreeBSD 10 reached EoL a while ago and it now emits a compatibility error, I'd like to drop it from CI, and add FreeBSD 13 instead, which is being developed currently.
Also, set up some basic bors re-label config for reviewing.

Btw, I'm worried about us renaming job names at each release time and I'm wondering if it may be a burden for the infra team as we should deploy rcs when changing the config.
We could rename jobs like `freebsd-1`, `freebsd-2`, etc. but it's unclear what the version we run.
If you have a better idea, I'm happy to hear it :) (I'm also fine to merge this as-is.)